### PR TITLE
SupportedByAttribute added (UIKit only)

### DIFF
--- a/MvvmKit/Views/ViewsContainer.cs
+++ b/MvvmKit/Views/ViewsContainer.cs
@@ -14,7 +14,7 @@ public abstract class ViewsContainer : IViewsContainer
 		this.secondaryViewFinders = new();
 	}
 
-	public void AddAll(IDictionary<Type, Type> viewModelViewLookup)
+	public virtual void AddAll(IDictionary<Type, Type> viewModelViewLookup)
 	{
 		foreach (var pair in viewModelViewLookup)
 		{
@@ -22,19 +22,19 @@ public abstract class ViewsContainer : IViewsContainer
 		}
 	}
 
-	public void Add(Type viewModelType, Type viewType)
+	public virtual void Add(Type viewModelType, Type viewType)
 	{
 		this.bindingMap[viewModelType] = viewType;
 	}
 
-	public void Add<TViewModel, TView>()
+	public virtual void Add<TViewModel, TView>()
 		where TViewModel : IViewModel
 		where TView : IView
 	{
 		Add(typeof(TViewModel), typeof(TView));
 	}
 
-	public Type GetViewType(Type? viewModelType)
+	public virtual Type GetViewType(Type? viewModelType)
 	{
 		if (viewModelType is not null && this.bindingMap.TryGetValue(viewModelType, out var binding))
 		{

--- a/Platforms/Ios/MvvmKit.Platforms.Ios.Abstractions/Presenters/SupportedByAttribute.cs
+++ b/Platforms/Ios/MvvmKit.Platforms.Ios.Abstractions/Presenters/SupportedByAttribute.cs
@@ -1,0 +1,10 @@
+namespace MvvmKit.Platforms.Ios.Abstractions.Presenters;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class SupportedByAttribute : Attribute
+{
+	public UIUserInterfaceIdiom UserInterfaceIdiom { get; }
+
+	public SupportedByAttribute(UIUserInterfaceIdiom userInterfaceIdiom)
+		=> this.UserInterfaceIdiom = userInterfaceIdiom;
+}


### PR DESCRIPTION
SupportedByAttribute takes `UIUserInterfaceIdiom` as input param. You can have multiple to mark you view controllers. That way, you can specify which on which platform that view controller should be resolved and presented.